### PR TITLE
v1.1.1: Codebase cleanup and documentation audit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,7 @@ yarn-debug.log*
 yarn-error.log*
 
 # OS files
-.DS_Store?
+.DS_Store
 ._*
 .Spotlight-V100
 .Trashes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1.1] - 2026-03-02
+
+### Fixed
+
+- Fix `.gitignore`: `.DS_Store?` glob didn't match `.DS_Store` — the `?` wildcard requires one trailing character, so the actual `.DS_Store` file was never ignored
+- Fix `README.md`: remove duplicate `.github/workflows/ci.yml` entry from project structure (listed both in tree and as standalone root entry)
+- Fix `README.md`: add missing root-level files to project structure (`index.html`, `package.json`, tsconfig files, `vite.config.ts`, `vitest.config.ts`, `eslint.config.js`, `README.md`)
+- Fix `README.md`: add missing `apple-touch-icon.png` to public directory listing
+- Fix `tasks/todo.md`: mark stale unchecked v1.1.0 item as complete (was already merged via PR #8)
+
 ## [1.1.0] - 2026-03-02
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ SafariServe/
 ├── .github/workflows/
 │   └── ci.yml                  # CI pipeline (lint, typecheck, test, build)
 ├── public/
+│   ├── apple-touch-icon.png    # iOS home screen icon (180x180)
 │   ├── favicon.svg             # App icon (compass rose motif)
 │   └── manifest.json           # PWA manifest
 ├── src/
@@ -94,12 +95,20 @@ SafariServe/
 │   └── index.css             # Tailwind imports + design tokens
 ├── .editorconfig             # Editor formatting rules
 ├── .gitignore                # Git ignore rules
-├── .github/workflows/ci.yml  # CI pipeline
-├── CLAUDE.md                 # Engineering standards
 ├── CHANGELOG.md              # Project changelog
+├── CLAUDE.md                 # Engineering standards
 ├── CODE_OF_CONDUCT.md        # Contributor Covenant
 ├── LICENSE                   # Apache License 2.0
+├── README.md                 # This file
 ├── SECURITY.md               # Vulnerability reporting
+├── eslint.config.js          # ESLint 9 flat config
+├── index.html                # HTML entry point
+├── package.json              # Dependencies and scripts
+├── tsconfig.json             # TypeScript project references
+├── tsconfig.app.json         # TypeScript config for src/
+├── tsconfig.node.json        # TypeScript config for build tooling
+├── vite.config.ts            # Vite build configuration
+├── vitest.config.ts          # Vitest test configuration
 └── tasks/
     ├── lessons.md            # Accumulated development lessons
     └── todo.md               # Active task tracking

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "safariserve",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "safariserve",
-      "version": "1.0.0",
+      "version": "1.1.1",
       "dependencies": {
         "lucide-react": "^0.474.0",
         "react": "^19.0.0",
@@ -1747,6 +1747,70 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "safariserve",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "description": "Your gateway to Safari, from anywhere.",
   "scripts": {

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -35,7 +35,7 @@ describe("App", () => {
     render(<App />);
     expect(screen.getByText("VASEY/AI PRESENTS")).toBeInTheDocument();
     expect(screen.getByText("SafariServe")).toBeInTheDocument();
-    expect(screen.getByText("v1.1")).toBeInTheDocument();
+    expect(screen.getByText("v1.1.1")).toBeInTheDocument();
     expect(
       screen.getByText("Your gateway to Safari, from anywhere."),
     ).toBeInTheDocument();

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -21,7 +21,7 @@ export function Header() {
           SafariServe
         </h1>
         <span className="px-2 py-0.5 rounded-full bg-safari-cyan/10 border border-safari-cyan/20 text-safari-cyan text-[10px] font-bold ml-1 tracking-wider">
-          v1.1
+          v1.1.1
         </span>
       </div>
       <p className="text-safari-text/50 text-sm font-medium tracking-wide">

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -26,3 +26,10 @@ Accumulated patterns from corrections and mistakes. Reviewed at the start of eac
 - **Semantic HTML**: Use `<header>`, `<ul>/<li>`, and `role="list"` for list elements with `list-none` to preserve VoiceOver list semantics.
 - **Type safety over casts**: Prefer typed function signatures (`type: MediaType`) over runtime casts (`type as MediaType`). Catches misuse at compile time.
 - **Non-functional UI elements**: Never render buttons/tabs that do nothing when clicked. Either implement them or remove them.
+
+## 2026-03-02 — v1.1.1 Codebase Cleanup & Documentation Audit
+
+- **`.gitignore` glob pitfall**: `.DS_Store?` does NOT match `.DS_Store` — the `?` wildcard matches exactly one character, so it only matches files like `.DS_StoreX`. Use `.DS_Store` (no wildcard) to match the actual macOS metadata file.
+- **README project structure accuracy**: When documenting project structure, list ALL root-level files including build/config files (`index.html`, `package.json`, tsconfigs, vite/vitest configs, eslint config). Don't duplicate entries that already appear in the tree hierarchy (e.g., `ci.yml` was listed both inside `.github/workflows/` tree and again as a standalone root entry).
+- **Stale task tracking**: Mark todo items as complete when their associated PRs are merged. Unchecked items in completed sessions create confusion about actual state.
+- **Version consistency across files**: When bumping version, update ALL locations: `package.json`, Header component badge, test assertions that check the version string, and CHANGELOG.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,6 +1,20 @@
 # Task Plan
 
-## Current Session: v1.1.0 — Issue Fixes & Code Quality
+## Current Session: v1.1.1 — Codebase Cleanup & Documentation Audit
+
+- [x] Full codebase audit for merge conflicts, duplicates, and bad merges
+- [x] Run all verification checks (lint, typecheck, tests, build)
+- [x] Deep-read every file in the repository
+- [x] Fix `.gitignore`: `.DS_Store?` glob doesn't match `.DS_Store` — changed to `.DS_Store`
+- [x] Fix `README.md`: remove duplicate `.github/workflows/ci.yml` entry from project structure
+- [x] Fix `README.md`: add missing root-level files to project structure
+- [x] Fix `README.md`: add missing `apple-touch-icon.png` to public directory listing
+- [x] Clean up stale unchecked item from previous v1.1.0 session
+- [x] Update CHANGELOG with v1.1.1 fixes
+- [x] Re-run all verification checks
+- [ ] Commit and push to feature branch
+
+## Previous Session: v1.1.0 — Issue Fixes & Code Quality
 
 - [x] Fix Issue #3: Remove duplicate `.DS_Store` entry in `.gitignore`
 - [x] Fix Issue #4: Add enforcement contact email to `CODE_OF_CONDUCT.md`
@@ -21,7 +35,7 @@
 - [x] Update version to 1.1.0 (package.json, Header badge)
 - [x] Update CHANGELOG with v1.1.0 release notes
 - [x] Verify: lint (0 warnings), typecheck (clean), tests (35 pass), build (success)
-- [ ] Commit and push to feature branch
+- [x] Commit and push to feature branch
 
 ## Previous Session: SafariServe v1.0 Implementation
 


### PR DESCRIPTION
## Summary

This release performs a comprehensive codebase audit and fixes documentation inconsistencies discovered during a full repository review. Includes critical `.gitignore` fix, README structure corrections, and version bump to 1.1.1.

## Key Changes

- **Fix `.gitignore` glob pattern**: Changed `.DS_Store?` to `.DS_Store` — the `?` wildcard requires exactly one trailing character, so `.DS_Store` files were never actually ignored
- **Update `README.md` project structure**:
  - Remove duplicate `.github/workflows/ci.yml` entry (was listed both in tree and as standalone root file)
  - Add missing root-level files: `index.html`, `package.json`, tsconfig files, `vite.config.ts`, `vitest.config.ts`, `eslint.config.js`, `README.md`
  - Add missing `apple-touch-icon.png` to public directory listing
- **Version bump to 1.1.1**: Updated in `package.json`, `Header.tsx` badge, and test assertion
- **Update `CHANGELOG.md`**: Document all v1.1.1 fixes with detailed explanations
- **Update `tasks/todo.md`**: Mark v1.1.0 commit task as complete (was already merged via PR #8) and create v1.1.1 session tracking
- **Update `tasks/lessons.md`**: Add lessons learned about `.gitignore` glob patterns, README accuracy, task tracking, and version consistency

## Notable Details

The `.gitignore` fix is particularly important: the `?` wildcard in glob patterns matches exactly one character, making `.DS_Store?` match files like `.DS_StoreX` but not the actual `.DS_Store` file. This means macOS metadata files were being committed despite the ignore rule.

https://claude.ai/code/session_0161TihyFjVmVecmDw6GrL6p