### PR TITLE
fix: restore GitHub Pages loading and add pages deployment workflow

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,53 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build for GitHub Pages
+        run: npm run build
+        env:
+          BASE_PATH: /SafariServe/
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Fixed
+
+- Fix GitHub Pages loading by making Vite base path configurable via `BASE_PATH` (defaults to `/` for local/Vercel)
+- Fix PWA manifest pathing for subpath deployments by using relative icon URLs and `start_url: "."`
+
+### Added
+
+- Add dedicated GitHub Pages deployment workflow (`deploy-pages.yml`) that builds with `BASE_PATH=/SafariServe/` and deploys `dist/`
+- Add deployment documentation for GitHub Pages and Vercel plus a Pages-specific build command in README
+
 ## [1.1.1] - 2026-03-02
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ npm run dev
 npm run build
 ```
 
+To build for GitHub Pages (repo subpath deployment), set `BASE_PATH`:
+
+```bash
+BASE_PATH=/SafariServe/ npm run build
+```
+
 ### Test
 
 ```bash
@@ -73,6 +79,7 @@ npm run typecheck
 SafariServe/
 ├── .github/workflows/
 │   └── ci.yml                  # CI pipeline (lint, typecheck, test, build)
+│   └── deploy-pages.yml        # GitHub Pages build + deployment workflow
 ├── public/
 │   ├── apple-touch-icon.png    # iOS home screen icon (180x180)
 │   ├── favicon.svg             # App icon (compass rose motif)
@@ -133,6 +140,11 @@ SafariServe integrates with Apple Shortcuts via:
 3. **Home Screen Generator** — Create named, iconified shortcuts for the Home Screen
 
 URLs can be passed via the `?url=` query parameter for automated workflows.
+
+## Deployment
+
+- **GitHub Pages**: `.github/workflows/deploy-pages.yml` builds on `main` with `BASE_PATH=/SafariServe/` and deploys the `dist/` artifact to Pages.
+- **Vercel**: Works with the default build command (`npm run build`) and no `BASE_PATH` override.
 
 ## Contributing
 

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -2,18 +2,18 @@
   "name": "SafariServe",
   "short_name": "SafariServe",
   "description": "Your gateway to Safari, from anywhere.",
-  "start_url": "/",
+  "start_url": ".",
   "display": "standalone",
   "background_color": "#0A0E14",
   "theme_color": "#0A0E14",
   "icons": [
     {
-      "src": "/favicon.svg",
+      "src": "favicon.svg",
       "sizes": "any",
       "type": "image/svg+xml"
     },
     {
-      "src": "/apple-touch-icon.png",
+      "src": "apple-touch-icon.png",
       "sizes": "180x180",
       "type": "image/png"
     }

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,6 +1,19 @@
 # Task Plan
 
-## Current Session: v1.1.1 — Codebase Cleanup & Documentation Audit
+## Current Session: GitHub Pages Load Fix + Deployment Hardening
+
+- [x] Review `tasks/lessons.md` and current repo state
+- [x] Reproduce/triangulate deployment issue by auditing build and asset path configuration
+- [x] Update Vite config to support subpath deployments (GitHub Pages) while preserving local/Vercel behavior
+- [x] Fix PWA manifest paths/start URL for repo-subpath hosting
+- [x] Add GitHub Pages deployment workflow with CI-compatible build + artifact publish
+- [x] Update README deployment documentation for GitHub Pages and Vercel
+- [x] Update CHANGELOG with deployment fix details
+- [x] Run full verification suite (lint, typecheck, test, build)
+- [x] Capture UI screenshot of running app (not applicable: no visual component changes)
+- [x] Commit changes with conventional commit message
+
+## Previous Session: v1.1.1 — Codebase Cleanup & Documentation Audit
 
 - [x] Full codebase audit for merge conflicts, duplicates, and bad merges
 - [x] Run all verification checks (lint, typecheck, tests, build)
@@ -70,3 +83,10 @@
 - [x] Create `CODE_OF_CONDUCT.md` (Contributor Covenant)
 - [x] Update `README.md` with proper structure and project description
 - [x] Commit and push initialization to `claude/init-claude-md-ncO4c`
+
+
+## Review
+
+- Root cause identified: production bundle used `/` base, causing broken asset links on GitHub Pages subpath (`/SafariServe/`).
+- Mitigation implemented: environment-driven Vite base + Pages-specific deploy workflow + relative manifest paths.
+- Verification: local lint/typecheck/test/build and Pages-style build with `BASE_PATH=/SafariServe/`.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,12 @@
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 
-export default defineConfig({
-  plugins: [react(), tailwindcss()],
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, ".", "");
+
+  return {
+    base: env.BASE_PATH || "/",
+    plugins: [react(), tailwindcss()],
+  };
 });


### PR DESCRIPTION
### Motivation

- The production site under the repository subpath (`/SafariServe/`) was failing because the production bundle used root-relative asset and manifest URLs built for `/`, causing broken assets and PWA issues.  
- Provide a safe, environment-driven build that preserves local/Vercel behavior while allowing GitHub Pages to build for the repo subpath and be deployed by CI.

### Description

- Make Vite `base` configurable via `BASE_PATH` by loading environment values in `vite.config.ts` and defaulting `base` to `/` for local/Vercel builds.  
- Make the PWA manifest subpath-safe by changing `start_url` to `"."` and switching the icon `src` values to relative paths in `public/manifest.json`.  
- Add a GitHub Actions workflow `.github/workflows/deploy-pages.yml` that builds with `BASE_PATH=/SafariServe/`, uploads the `dist/` artifact, and deploys with `actions/deploy-pages`.  
- Update documentation and bookkeeping files: add Pages build instructions to `README.md`, add an `Unreleased` entry to `CHANGELOG.md`, and update `tasks/todo.md` to record the verification steps completed.

### Testing

- Ran linting with `npm run lint` and it completed successfully.  
- Ran type checking with `npm run typecheck` and it completed successfully.  
- Ran unit tests with `npm run test` and all tests passed (`35` tests across 3 files).  
- Built the production bundle with `npm run build` and performed a Pages-style build with `BASE_PATH=/SafariServe/ npm run build`, then inspected `dist/index.html` to confirm asset, manifest and icon links are prefixed with `/SafariServe/` as expected, and both builds completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6bcba1f80832faf6c1d6863980afe)