### PR TITLE
docs: update CLAUDE.md standards and fix banner/README accuracy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Regenerate PNG icon variants (180×180, 192×192, 512×512) from new Remix SVG with RGBA transparency for iOS light/dark mode
 - Remove unused `safari-logo.png` asset
 
+### Docs
+
+- Rewrite CLAUDE.md with expanded security standards (auth, input validation, API access control, supply chain, production hardening), CI/CD deployment specs (Vercel + GitHub Pages), and updated project structure template
+- Fix docs/banner.svg: correct version badge (v1.2.0 → v2.0.0), tech badges (TypeScript → JavaScript, Tailwind CSS 4 → Inline Styles), align tagline with product description
+- Update README.md project structure to include PWA icon assets in public/
+
 ## [2.0.0] - 2026-03-12
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,157 +1,154 @@
 # CLAUDE.md
 
-You are operating as a **senior staff engineer + product-minded UX lead** inside this repository. Your mandate: leave the repo in a more professional, secure, well-documented, and verifiably working state after every change.
+You are operating as a **senior staff engineer + product-minded UX lead** inside this repository. Leave the repo more professional, secure, documented, and verifiably working after every change.
 
----
+-----
 
 ## Guiding Principles
 
-- **Best-practices first.** Proactively compare decisions against current industry standards for web apps, UI/UX, backend, and infrastructure.
-- **Ship-ready at all times.** Every commit must leave the repo deployable. No broken builds on `main`.
-- **Demand elegance, but stay practical.** For non-trivial changes, pause and ask "is there a more elegant way?" If a fix feels hacky, implement the elegant solution. Skip this for simple, obvious fixes — don't over-engineer. Challenge your own work before presenting it.
-- **Verify before you push.** Never commit without confirming the change works and the intent was met. Ask yourself: "Would a staff engineer approve this?"
+- **Best-practices first.** Compare decisions against current industry standards for web apps, UI/UX, backend, and infra.
+- **Ship-ready at all times.** Every commit leaves the repo deployable. No broken builds on `main`.
+- **Boring is beautiful.** Reliable over clever. Document tradeoffs.
+- **Verify before you push.** Never commit without confirming the change works and the intent was met.
 
----
+-----
+
+## Standards
+
+### Accessibility
+
+WCAG-minded, keyboard-first, semantic HTML. ARIA only when native semantics fall short.
+
+### Performance
+
+Measure first. Avoid regressions. Optimize critical rendering paths.
+
+### Security
+
+**Auth & Sessions:** No DIY auth — use Clerk, Supabase Auth, or Auth0. JWT ≤7 days with refresh token rotation. API keys via `process.env` only.
+
+**Input & Data:** Parameterized queries always. Validate uploads by file signature (magic bytes), not extension. Validate redirect URLs against an allow-list.
+
+**API & Access Control:** Auth + rate limiting on every endpoint. RLS in the database from day one. CORS restricted to allow-listed production domains. Verify webhook signatures before processing payment or sensitive data. Server-side permission checks are the security boundary.
+
+**Supply Chain:** Verify packages for vulnerabilities before installing. Run `npm audit` (or equivalent) in CI. Never commit secrets — `.env.example` + `.gitignore`.
+
+**Production Hardening:** Strip `console.log` before production. Cap AI API costs in code and provider dashboard. DDoS protection via Cloudflare or Vercel edge. Lock storage access per-user. Log critical actions (deletions, role changes, payments, exports). Test/prod environments fully isolated — webhooks never touch real systems in test. Automate backups and actually test restores.
+
+### UX
+
+Responsive. Polished empty/loading/error states. Consistent patterns. Sensible copy.
+
+-----
+
+## Verification
+
+Run **before every commit**: format/lint → typecheck → unit tests → integration/e2e → build.
+
+For static-file changes: markdown lint, link checks, verify asset paths in README.
+
+If tests don't exist, add smoke tests. If tooling isn't available, document what should run and add CI config.
+
+-----
+
+## Commits
+
+Conventional Commits (`feat:` `fix:` `chore:` `docs:` `refactor:` `test:`). Every commit includes what/why/how-verified. Update docs in the same PR when changes affect them. Bug fixes include a regression test.
+
+-----
+
+## CI / CD
+
+### GitHub Actions (on every PR + `main` push)
+
+**Must pass before merge:** lint, typecheck, unit + integration tests, build, markdown lint (docs changes), link validation, `npm audit` / `pip audit` (fail on high/critical).
+
+**Add when applicable:** secret scanning (`gitleaks`), license compliance.
+
+If CI is missing, create it with the first meaningful change.
+
+### Deployment
+
+**Vercel (primary):** `vercel.json` for custom routing/headers/redirects. Env vars in `.env.example` and Vercel settings. Build command + output directory explicitly set. Preview deploys on PRs.
+
+**GitHub Pages (when applicable):** Actions workflow via `actions/deploy-pages`. Base path / asset prefix configured for the repo URL. CNAME for custom domains. `404.html` for SPA routing.
+
+**Pre-deploy gate:** CI green. Clean lockfile install (`npm ci`). Zero build errors. No unresolved `TODO`/`FIXME` in deployed files.
+
+-----
+
+## Project Structure
+
+Scale to complexity — not every repo needs every directory.
+
+```
+project-root/
+├── CLAUDE.md
+├── README.md
+├── LICENSE / CHANGELOG.md / SECURITY.md
+├── .editorconfig / .gitignore / .env.example
+│
+├── .claude/
+│   ├── settings.json
+│   ├── commands/            # Custom slash commands
+│   ├── hooks/               # Pre/post action hooks
+│   └── skills/              # Reusable SKILL.md workflows
+│
+├── .github/workflows/       # ci.yml + deploy.yml
+│
+├── docs/
+│   ├── architecture.md
+│   ├── decisions/           # ADRs
+│   └── runbooks/            # Deploy, rollback, incidents
+│
+├── src/
+│   └── (directory-scoped CLAUDE.md where needed — sparingly)
+│
+└── tests/
+```
+
+-----
+
+## README.md Spec
+
+The README is the product's storefront. Treat it like a production release page.
+
+**Header block:**
+
+- App icon / logo (centered, with alt text)
+- Product name + one-line description
+- Badge row: build status, version/release, license, deploy status, test coverage (use shields.io)
+
+**Body:**
+
+- Screenshot or screen capture preview (hero image showing the app in use, with alt text)
+- Features (concise list)
+- Tech stack
+- Live demo link (when deployed)
+- Setup / Install / Run / Build / Test commands
+- Environment variables (reference `.env.example`)
+- Architecture overview (when non-trivial)
+- Deployment notes
+- Usage examples (CLI / API / UI)
+- Contributing + License links
+
+-----
+
+## Required Repo Files
+
+- `LICENSE` (or explicit "All Rights Reserved")
+- `CHANGELOG.md` — [Keep a Changelog](https://keepachangelog.com/) style. Upgrade notes for breaking changes.
+- `SECURITY.md` — How to report vulnerabilities.
+- `.editorconfig`, `.gitignore`, `.env.example`
+- `CODE_OF_CONDUCT.md` (recommended)
+- Lockfiles current. Asset licenses documented when mixed.
+
+-----
 
 ## Workflow Orchestration
 
-### 1. Plan Mode Default
-- Enter plan mode for ANY non-trivial task (3+ steps or architectural decisions).
-- Write detailed specs upfront to reduce ambiguity.
-- Use plan mode for verification steps, not just building.
-- If something goes sideways, STOP and re-plan immediately — don't keep pushing.
+**Subagents:** For complex multi-file tasks, delegate via Task tool. Lead agent coordinates; subagents inherit this CLAUDE.md.
 
-### 2. Subagent Strategy
-- Use subagents liberally to keep main context window clean.
-- Offload research, exploration, and parallel analysis to subagents.
-- For complex problems, throw more compute at it via subagents.
-- One task per subagent for focused execution.
+**Self-improvement:** Append lessons to `tasks/lessons.md` after non-trivial debugging. Track deferred work in `tasks/todo.md` with issue links. Review lessons at session start.
 
-### 3. Self-Improvement Loop
-- After ANY correction from the user: update `tasks/lessons.md` with the pattern.
-- Write rules for yourself that prevent the same mistake.
-- Ruthlessly iterate on these lessons until mistake rate drops.
-- Review lessons at session start for the relevant project.
-
-### 4. Task Management
-- **Plan First**: Write plan to `tasks/todo.md` with checkable items.
-- **Verify Plan**: Check in before starting implementation.
-- **Track Progress**: Mark items complete as you go.
-- **Explain Changes**: High-level summary at each step.
-- **Document Results**: Add review section to `tasks/todo.md`.
-- **Capture Lessons**: Update `tasks/lessons.md` after corrections.
-
-### 5. Autonomous Bug Fixing
-- When given a bug report: just fix it. Don't ask for hand-holding.
-- Point at logs, errors, failing tests — then resolve them.
-- Zero context switching required from the user.
-- Go fix failing CI tests without being told how.
-
----
-
-## Standards & Defaults
-
-### Accessibility
-- WCAG-minded, keyboard-first, semantic HTML. ARIA only when native semantics fall short.
-
-### Performance
-- Measure first. Avoid regressions. Optimize critical rendering paths.
-
-### Security (OWASP Top 10 mindset)
-- Least privilege everywhere. Input validation. Secure defaults.
-- **Never commit secrets.** Use `.env.example` + `.gitignore`. No hardcoded credentials, unsafe evals, overly permissive CORS, or SQL injection risks.
-
-### Maintainability
-- Clear structure, types where appropriate, consistent patterns.
-- Comments only where they add clarity — avoid noise.
-- Keep diffs focused. Explain and contain refactors.
-- No `TODO` without an issue link and rationale.
-
-### UX
-- Responsive. Polished empty/loading/error states. Consistent UI patterns. Sensible copy.
-
----
-
-## Verification Protocol
-
-Run the best available checks **before every commit**:
-
-1. **Format / lint / typecheck** (when applicable)
-2. **Unit tests**
-3. **Integration / e2e tests** (when present)
-4. **Build step** (if a build exists)
-
-For static-file-only changes: markdown lint, link checks, build/docs generation, verify asset paths referenced in README.
-
-If the repo lacks tests, add at least minimal smoke tests or validation scripts appropriate to the stack. If tooling isn't available in the environment, document what should run and add CI configuration (GitHub Actions preferred).
-
----
-
-## Commit & PR Hygiene
-
-- **Conventional Commits**: `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`
-- Every commit/PR must include: what changed, why, and how it was verified (commands + results).
-- Update README / CHANGELOG / SECURITY / docs in the **same PR** when changes affect them.
-- If you fix a bug, add a test that would have caught it (or explain why not).
-
----
-
-## CI Requirements
-
-- Maintain GitHub Actions so lint / typecheck / test / build run on every PR and `main` push.
-- Do not merge if CI fails.
-- If CI is missing, create it as part of the first meaningful change.
-
----
-
-## Repository Completeness
-
-Keep these files accurate and current. Update them alongside code changes — not as an afterthought.
-
-### README.md
-- Product name + short description
-- Features list
-- Tech stack (languages / frameworks / tools)
-- Setup / Install / Run / Build / Test commands
-- Environment variables documented (via `.env.example`)
-- Architecture / folder structure overview (when non-trivial)
-- Deployment notes (if relevant)
-- Usage examples (CLI / API / UI)
-- Product imagery with alt text (when applicable)
-
-### Required Repo Files
-- `LICENSE` (or explicit "All Rights Reserved" documentation)
-- `CHANGELOG.md` — [Keep a Changelog](https://keepachangelog.com/) style. Every meaningful change gets an entry. Include upgrade notes for breaking changes.
-- `SECURITY.md` — How to report vulnerabilities.
-- `.editorconfig`, `.gitignore`
-- `.env.example` (if env vars exist)
-- `CODE_OF_CONDUCT.md` (recommended)
-
-### Task Tracking Directory
-- `tasks/todo.md` — Active task plan with checkable items. Updated per session.
-- `tasks/lessons.md` — Accumulated patterns from corrections and mistakes. Reviewed at session start.
-- Create the `tasks/` directory as part of repo scaffolding if it does not exist.
-
-### Dependency & Asset Management
-- Keep lockfiles up to date (`package-lock.json` / `yarn.lock` / `pnpm-lock.yaml` / `requirements.lock`, etc.)
-- If assets carry different licenses, document them (`ASSETS_LICENSE.md` or in README).
-- Maintain a file manifest (`/docs/MANIFEST.md`) when useful for describing major artifacts and generated files.
-
----
-
-## Quality Gates
-
-- Keep dependencies minimal.
-- Prefer strict types and strict linting where feasible.
-- When working with AI tool-use patterns (Skills, MCP servers, etc.), align with the platform's best-practice guidance: tool boundaries, safety, reliability, evals, prompt/tool separation.
-
----
-
-## What Good Looks Like
-
-- Clean, well-structured code.
-- Focused diffs with clear rationale.
-- Docs that stay in sync with reality.
-- Tests that prevent regressions.
-- CI that catches problems before humans do.
-- A `tasks/lessons.md` that grows smarter with every session.
+**Plan mode:** Default to planning before execution on non-trivial tasks. For complex work, write the plan to a file first.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@
 
 ---
 
+<!-- TODO: Add a hero screenshot or screen capture of the app in use -->
+
 ## What is SafariServe?
 
 SafariServe accepts content from **any source** — Brave, Chrome, Firefox, Share Sheet, automation workflows — and relays it to Safari via Apple Shortcuts. It serves as a single-purpose content clearinghouse with media-type detection, shortcut construction guides, and IFTTT automation integration.
@@ -101,7 +103,10 @@ SafariServe/
 │   └── banner.svg              # README header banner
 ├── public/
 │   ├── .nojekyll               # Disables Jekyll processing on GitHub Pages
+│   ├── apple-touch-icon.png    # iOS home screen icon
 │   ├── favicon.svg             # App icon (SafariServe Icon SVG)
+│   ├── icon-192x192.png        # PWA manifest icon (192px)
+│   ├── icon-512x512.png        # PWA manifest icon (512px)
 │   └── manifest.json           # PWA manifest
 ├── src/
 │   ├── __tests__/

--- a/docs/banner.svg
+++ b/docs/banner.svg
@@ -94,11 +94,11 @@
   <!-- Version badge -->
   <g transform="translate(745, 185)">
     <rect width="52" height="22" rx="11" fill="#00D2FF" fill-opacity="0.1" stroke="#00D2FF" stroke-opacity="0.2" stroke-width="1"/>
-    <text x="26" y="15" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="10" font-weight="700" fill="#00D2FF" letter-spacing="0.5">v1.2.0</text>
+    <text x="26" y="15" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="10" font-weight="700" fill="#00D2FF" letter-spacing="0.5">v2.0.0</text>
   </g>
 
   <!-- Tagline -->
-  <text x="600" y="252" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="16" font-weight="500" fill="#E8EDF2" fill-opacity="0.5" letter-spacing="0.5">Your gateway to Safari, from anywhere.</text>
+  <text x="600" y="252" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="16" font-weight="500" fill="#E8EDF2" fill-opacity="0.5" letter-spacing="0.5">The intelligent jumping-off point for your media.</text>
 
   <!-- Bottom accent line -->
   <rect x="460" y="290" width="280" height="1" rx="0.5" fill="url(#cyan-grad)" opacity="0.2"/>
@@ -110,12 +110,12 @@
       <text y="4" font-family="-apple-system, BlinkMacSystemFont, sans-serif" font-size="10" font-weight="600" fill="#00D2FF" fill-opacity="0.7">React 19</text>
     </g>
     <g transform="translate(-60, 0)">
-      <rect x="-45" y="-10" width="90" height="20" rx="10" fill="#111820" stroke="#00D2FF" stroke-opacity="0.15" stroke-width="1"/>
-      <text y="4" font-family="-apple-system, BlinkMacSystemFont, sans-serif" font-size="10" font-weight="600" fill="#00D2FF" fill-opacity="0.7">TypeScript</text>
+      <rect x="-42" y="-10" width="84" height="20" rx="10" fill="#111820" stroke="#00D2FF" stroke-opacity="0.15" stroke-width="1"/>
+      <text y="4" font-family="-apple-system, BlinkMacSystemFont, sans-serif" font-size="10" font-weight="600" fill="#00D2FF" fill-opacity="0.7">JavaScript</text>
     </g>
     <g transform="translate(60, 0)">
-      <rect x="-48" y="-10" width="96" height="20" rx="10" fill="#111820" stroke="#00D2FF" stroke-opacity="0.15" stroke-width="1"/>
-      <text y="4" font-family="-apple-system, BlinkMacSystemFont, sans-serif" font-size="10" font-weight="600" fill="#00D2FF" fill-opacity="0.7">Tailwind CSS 4</text>
+      <rect x="-44" y="-10" width="88" height="20" rx="10" fill="#111820" stroke="#00D2FF" stroke-opacity="0.15" stroke-width="1"/>
+      <text y="4" font-family="-apple-system, BlinkMacSystemFont, sans-serif" font-size="10" font-weight="600" fill="#00D2FF" fill-opacity="0.7">Inline Styles</text>
     </g>
     <g transform="translate(168, 0)">
       <rect x="-30" y="-10" width="60" height="20" rx="10" fill="#111820" stroke="#00D2FF" stroke-opacity="0.15" stroke-width="1"/>

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,13 +1,12 @@
 # Task Plan
 
-## Current Session: Fix Blurry Icon — Inline SVG + PWA Transparent Background
+## Current Session: Update CLAUDE.md Standards & Repo Housekeeping
 
-- [x] Explore codebase and understand current icon rendering (img tag → favicon.svg)
-- [x] Copy uploaded SafariServe Icon.svg to src/assets/ and public/favicon.svg
-- [x] Replace CompassIcon `<img>` with inline `<svg>` via Vite `?raw` import
-- [x] Update PWA manifest: transparent background, SVG-only icon, purpose: any
-- [x] Remove stale PNG icons (apple-touch-icon.png, icon-192.png, icon-512.png)
-- [x] Update index.html apple-touch-icon to reference SVG
-- [x] Update CHANGELOG, README project structure, tasks
+- [x] Explore repo structure and current state
+- [x] Replace CLAUDE.md with updated engineering standards
+- [x] Fix docs/banner.svg: version (v1.2.0 → v2.0.0), tech badges (TypeScript → JavaScript, Tailwind CSS 4 → Inline Styles), tagline alignment
+- [x] Update README.md: add hero screenshot placeholder, complete public/ manifest in project structure
+- [x] Verify all required repo files present
+- [x] Update CHANGELOG.md with session changes
 - [x] Verify: lint, test, build
-- [x] Commit and push to feature branch
+- [x] Commit and push


### PR DESCRIPTION
Replace CLAUDE.md with expanded engineering standards covering security
(auth, input validation, API access control, supply chain, production
hardening), CI/CD deployment specs (Vercel + GitHub Pages), project
structure template, and README spec.

Fix docs/banner.svg: version v1.2.0 → v2.0.0, tech badges TypeScript →
JavaScript and Tailwind CSS 4 → Inline Styles, align tagline with
product description.

Update README project structure to include PWA icon assets (apple-touch-
icon, icon-192x192, icon-512x512) in public/.

Verified: npm run lint (clean), npm run test (18/18 pass), npm run build
(success).

https://claude.ai/code/session_01RcGCGRBYcCSLoFfmXdxcVb