### PR TITLE
feat: shared URL intake, real IFTTT webhook, validation & accessibility (v2.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,31 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [2.1.0] - 2026-07-12
+
+### Added
+
+- Accept shared URLs via the `?url=` query parameter (previously documented but not implemented) — the Send to Serve shortcut flow now pre-fills the Route tab on load
+- Functional IFTTT webhook integration: configure your Maker event name + key in the Automate tab (persisted to browser localStorage only), then dispatch real payloads from the Route tab with sending / dispatched / error feedback
+- URL validation: routing actions enable only for parseable http(s) URLs; bare domains (`example.com/page`) are accepted by assuming `https://`; `javascript:` and other non-web schemes are rejected
+- WAI-ARIA tabs pattern: `tablist`/`tab`/`tabpanel` roles, `aria-selected`, roving tabindex, and Arrow key navigation between tabs
+- `prefers-reduced-motion` support: the canvas mesh renders a single static frame and CSS animations/transitions are effectively disabled for users who opt out of motion
+- Visible `:focus-visible` outlines for keyboard users
+- `aria-label`s on the URL input, copy button, and webhook config inputs; `aria-hidden` on the decorative canvas
+- 15 new tests covering shared-URL intake, validation, webhook config/dispatch, Save to Home Screen navigation, and tab accessibility (33 total)
+
 ### Changed
+
+- "Save to Home Screen" now opens the step-by-step guide in the Shortcuts tab (was a non-functional button)
+- Media type detection parses URLs and matches hostnames exactly (or by subdomain) instead of substring matching, so `evil.com/?ref=youtube.com` is no longer classified as video
+- Canvas background respects `devicePixelRatio` (capped at 2×) instead of hardcoding 2×, and spawns particles across the actual canvas dimensions
+- "Push to Safari" routes the normalized parsed URL and resets to idle a moment after completing
+
+### Removed
+
+- Placeholder `alert()` stub for the IFTTT webhook trigger
+
+### Changed (icons, previously unreleased)
 
 - Replace blurry `<img>`-based icon with inline `<svg>` loaded from file via Vite `?raw` import for crisp rendering at any size
 - Replace old compass favicon with uploaded SafariServe Icon SVG

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <p align="center">
   <a href="https://github.com/SeanVasey/SafariServe/actions/workflows/ci.yml"><img src="https://github.com/SeanVasey/SafariServe/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI"></a>
   <a href="https://github.com/SeanVasey/SafariServe/actions/workflows/deploy-pages.yml"><img src="https://github.com/SeanVasey/SafariServe/actions/workflows/deploy-pages.yml/badge.svg" alt="Deploy"></a>
-  <img src="https://img.shields.io/badge/version-2.0.0-00D2FF?style=flat&labelColor=0A0E14" alt="Version 2.0.0">
+  <img src="https://img.shields.io/badge/version-2.1.0-00D2FF?style=flat&labelColor=0A0E14" alt="Version 2.1.0">
   <a href="https://seanvasey.github.io/SafariServe/"><img src="https://img.shields.io/badge/demo-live-00B4D8?style=flat&labelColor=0A0E14" alt="Live Demo"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-FFB26B?style=flat&labelColor=0A0E14" alt="License"></a>
 </p>
@@ -25,9 +25,11 @@ SafariServe accepts content from **any source** — Brave, Chrome, Firefox, Shar
 ## Features
 
 - **Push to Safari** — Route any URL to Safari via the ForceSafari Apple Shortcut
-- **Media Type Detection** — Auto-classifies URLs as Video, Audio, Image, Document, or Article
+- **Shared URL Intake** — Arrives pre-filled via the `?url=` query parameter from the Send to Serve shortcut
+- **Media Type Detection** — Parses and validates URLs, classifying them as Video, Audio, Image, Document, or Article by hostname and file extension
 - **Shortcut Construction** — Step-by-step guides for building Send to Serve, ForceSafari, and Save to Home Screen shortcuts
-- **IFTTT Webhook Integration** — Trigger automation workflows via IFTTT Maker webhooks
+- **IFTTT Webhook Integration** — Configure your Maker event + key in-app (stored locally) and dispatch payloads to IFTTT automation workflows
+- **Accessible** — WAI-ARIA tabs with keyboard navigation, visible focus outlines, and `prefers-reduced-motion` support
 - **Animated Mesh Background** — Canvas-based electric cyan particle system with flowing ribbons
 - **PWA** — Installable as a Progressive Web App on the Home Screen
 - **Pipeline Flow** — Visual diagram: Brave → Send to Serve → SafariServe → ForceSafari → Safari

--- a/docs/banner.svg
+++ b/docs/banner.svg
@@ -94,7 +94,7 @@
   <!-- Version badge -->
   <g transform="translate(745, 185)">
     <rect width="52" height="22" rx="11" fill="#00D2FF" fill-opacity="0.1" stroke="#00D2FF" stroke-opacity="0.2" stroke-width="1"/>
-    <text x="26" y="15" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="10" font-weight="700" fill="#00D2FF" letter-spacing="0.5">v2.0.0</text>
+    <text x="26" y="15" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="10" font-weight="700" fill="#00D2FF" letter-spacing="0.5">v2.1.0</text>
   </g>
 
   <!-- Tagline -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "safariserve",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "safariserve",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "dependencies": {
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
@@ -54,13 +54,13 @@
       "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -69,9 +69,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -79,21 +79,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -110,14 +110,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -127,14 +127,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -144,9 +144,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -154,29 +154,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -196,9 +196,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -206,9 +206,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -216,9 +216,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -226,27 +226,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
-      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -298,33 +298,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -332,14 +332,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1737,15 +1737,15 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
-      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
         "chai": "^5.2.0",
         "tinyrainbow": "^2.0.0"
       },
@@ -1754,13 +1754,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
-      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.2.4",
+        "@vitest/spy": "3.2.7",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.17"
       },
@@ -1781,9 +1781,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
-      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1794,13 +1794,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
-      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "3.2.4",
+        "@vitest/utils": "3.2.7",
         "pathe": "^2.0.3",
         "strip-literal": "^3.0.0"
       },
@@ -1809,13 +1809,13 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
-      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
+        "@vitest/pretty-format": "3.2.7",
         "magic-string": "^0.30.17",
         "pathe": "^2.0.3"
       },
@@ -1824,9 +1824,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
-      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1837,13 +1837,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
-      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
+        "@vitest/pretty-format": "3.2.7",
         "loupe": "^3.1.4",
         "tinyrainbow": "^2.0.0"
       },
@@ -1963,9 +1963,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
-      "integrity": "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==",
+      "version": "2.10.43",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz",
+      "integrity": "sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1976,9 +1976,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1987,9 +1987,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.6.tgz",
+      "integrity": "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==",
       "dev": true,
       "funding": [
         {
@@ -2007,11 +2007,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.10.42",
+        "caniuse-lite": "^1.0.30001803",
+        "electron-to-chromium": "^1.5.389",
+        "node-releases": "^2.0.51",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -2041,9 +2041,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001775",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001775.tgz",
-      "integrity": "sha512-s3Qv7Lht9zbVKE9XoTyRG6wVDCKdtOFIjBGg3+Yhn6JaytuNKPIjBMTMIY1AnOH3seL5mvF+x33oGAyK3hVt3A==",
+      "version": "1.0.30001805",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001805.tgz",
+      "integrity": "sha512-52noaS3DubycKSXaU30TwPGIp+POyQSUVa5jBEq3vkRkY0kjyb3LQgvhU6WGyCcyXqVLWO0Cw0Q6BSdD0kUfVA==",
       "dev": true,
       "funding": [
         {
@@ -2271,9 +2271,9 @@
       "peer": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.302",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.302.tgz",
-      "integrity": "sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==",
+      "version": "1.5.389",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.389.tgz",
+      "integrity": "sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==",
       "dev": true,
       "license": "ISC"
     },
@@ -2643,9 +2643,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.4.tgz",
-      "integrity": "sha512-3+mMldrTAPdta5kjX2G2J7iX4zxtnwpdA8Tr2ZSjkyPSanvbZAcy6flmtnXbEybHrDcU9641lxrMfFuUxVz9vA==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -2868,10 +2868,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -3357,9 +3367,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
       "dev": true,
       "funding": [
         {
@@ -3383,11 +3393,14 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.27",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
-      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "version": "2.0.51",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/nwsapi": {
       "version": "2.2.23",
@@ -3517,9 +3530,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3530,9 +3543,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.17",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.17.tgz",
+      "integrity": "sha512-J7EF+8X+CzRPaJPOv9Ck2wNWJvGnnl3PcNPAdGg6GTLjyVpyQ0yATMSXRFRV01BviT/9Gwuc3rjEyJbDJG9a4w==",
       "dev": true,
       "funding": [
         {
@@ -3550,7 +3563,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -4050,9 +4063,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4148,20 +4161,20 @@
       }
     },
     "node_modules/vitest": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
-      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/chai": "^5.2.2",
-        "@vitest/expect": "3.2.4",
-        "@vitest/mocker": "3.2.4",
-        "@vitest/pretty-format": "^3.2.4",
-        "@vitest/runner": "3.2.4",
-        "@vitest/snapshot": "3.2.4",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
         "chai": "^5.2.0",
         "debug": "^4.4.1",
         "expect-type": "^1.2.1",
@@ -4191,8 +4204,8 @@
         "@edge-runtime/vm": "*",
         "@types/debug": "^4.1.12",
         "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.2.4",
-        "@vitest/ui": "3.2.4",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
         "happy-dom": "*",
         "jsdom": "*"
       },
@@ -4325,9 +4338,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "safariserve",
   "private": true,
-  "version": "2.0.0",
+  "version": "2.1.0",
   "type": "module",
   "description": "The intelligent jumping-off point for your media.",
   "scripts": {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -83,20 +83,24 @@ function ElectricMeshBackground() {
     const canvas = canvasRef.current;
     if (!canvas) return;
     const ctx = canvas.getContext("2d");
+    const prefersReducedMotion = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
     let animFrame;
     let particles = [];
     const resize = () => {
-      canvas.width = canvas.offsetWidth * 2;
-      canvas.height = canvas.offsetHeight * 2;
-      ctx.scale(2, 2);
+      const dpr = Math.min(window.devicePixelRatio || 1, 2);
+      canvas.width = canvas.offsetWidth * dpr;
+      canvas.height = canvas.offsetHeight * dpr;
+      // Setting width/height resets the transform, so this doesn't compound
+      ctx.scale(dpr, dpr);
     };
     resize();
     const w = () => canvas.offsetWidth;
     const h = () => canvas.offsetHeight;
-    // More particles, brighter
+    const spawnW = w() || 500;
+    const spawnH = h() || 1400;
     for (let i = 0; i < 80; i++) {
       particles.push({
-        x: Math.random() * 500, y: Math.random() * 1400,
+        x: Math.random() * spawnW, y: Math.random() * spawnH,
         vx: (Math.random() - 0.5) * 0.4, vy: (Math.random() - 0.5) * 0.25,
         r: Math.random() * 2.5 + 0.8, o: Math.random() * 0.8 + 0.3,
         pulse: Math.random() * Math.PI * 2,
@@ -191,24 +195,90 @@ function ElectricMeshBackground() {
           }
         }
       }
-      animFrame = requestAnimationFrame(draw);
+      // Respect prefers-reduced-motion: render a single static frame
+      if (!prefersReducedMotion) animFrame = requestAnimationFrame(draw);
     };
     draw();
     window.addEventListener("resize", resize);
     return () => { cancelAnimationFrame(animFrame); window.removeEventListener("resize", resize); };
   }, []);
-  return <canvas ref={canvasRef} style={{ position: "absolute", inset: 0, width: "100%", height: "100%", pointerEvents: "none" }} />;
+  return <canvas ref={canvasRef} aria-hidden="true" style={{ position: "absolute", inset: 0, width: "100%", height: "100%", pointerEvents: "none" }} />;
 }
 
-// ━━━ MEDIA TYPE DETECTION ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// ━━━ URL PARSING & MEDIA TYPE DETECTION ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// Parse user input into an http(s) URL. Bare domains ("example.com/page") get
+// an https:// prefix; anything else that fails to parse — or parses to a
+// non-web scheme like javascript: — returns null so it can never be routed.
+function parseWebUrl(raw) {
+  if (!raw) return null;
+  const trimmed = raw.trim();
+  let parsed = null;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    // Bare host-like input only: at least one dot, no spaces, no scheme
+    if (/^[a-z0-9-]+(\.[a-z0-9-]+)+(:\d+)?([/?#]|$)/i.test(trimmed)) {
+      try { parsed = new URL(`https://${trimmed}`); } catch { return null; }
+    }
+  }
+  if (!parsed || (parsed.protocol !== "http:" && parsed.protocol !== "https:")) return null;
+  return parsed;
+}
+
+const MEDIA_HOSTS = {
+  video: ["youtube.com", "youtu.be", "vimeo.com", "dailymotion.com", "twitch.tv"],
+  image: ["flickr.com", "unsplash.com"],
+  audio: ["soundcloud.com", "spotify.com", "music.apple.com"],
+  document: ["docs.google.com", "notion.so"],
+};
+
+// Exact or subdomain match — substring tricks like evil.com/?ref=youtube.com don't count
+function hostMatches(hostname, hosts) {
+  return hosts.some((h) => hostname === h || hostname.endsWith(`.${h}`));
+}
+
 function detectMediaType(url) {
-  if (!url) return "unknown";
-  const l = url.toLowerCase();
-  if (l.includes("youtube.com") || l.includes("youtu.be") || l.includes("vimeo") || l.includes("dailymotion") || l.includes("twitch.tv")) return "video";
-  if (l.match(/\.(jpeg|jpg|gif|png|webp|svg|heic|avif)(\?|$)/i) || l.includes("instagram.com/p/") || l.includes("flickr.com") || l.includes("unsplash.com")) return "image";
-  if (l.match(/\.(mp3|wav|flac|aac|ogg|m4a)(\?|$)/i) || l.includes("soundcloud.com") || l.includes("spotify.com") || l.includes("music.apple.com")) return "audio";
-  if (l.match(/\.(pdf|doc|docx|xls|xlsx|ppt|pptx)(\?|$)/i) || l.includes("docs.google.com") || l.includes("notion.so")) return "document";
+  const parsed = parseWebUrl(url);
+  if (!parsed) return "unknown";
+  const host = parsed.hostname.toLowerCase();
+  const path = parsed.pathname.toLowerCase();
+  if (hostMatches(host, MEDIA_HOSTS.video)) return "video";
+  if (/\.(jpeg|jpg|gif|png|webp|svg|heic|avif)$/.test(path) || hostMatches(host, MEDIA_HOSTS.image) || (hostMatches(host, ["instagram.com"]) && path.startsWith("/p/"))) return "image";
+  if (/\.(mp3|wav|flac|aac|ogg|m4a)$/.test(path) || hostMatches(host, MEDIA_HOSTS.audio)) return "audio";
+  if (/\.(pdf|doc|docx|xls|xlsx|ppt|pptx)$/.test(path) || hostMatches(host, MEDIA_HOSTS.document)) return "document";
   return "article";
+}
+
+// ━━━ IFTTT WEBHOOK CONFIG (persisted locally, never leaves the device) ━━━━
+const WEBHOOK_STORAGE_KEY = "safariserve.webhook";
+
+function loadWebhookConfig() {
+  try {
+    const raw = window.localStorage.getItem(WEBHOOK_STORAGE_KEY);
+    if (!raw) return { event: "", key: "" };
+    const parsed = JSON.parse(raw);
+    return { event: parsed.event || "", key: parsed.key || "" };
+  } catch {
+    return { event: "", key: "" };
+  }
+}
+
+function saveWebhookConfig(config) {
+  try {
+    window.localStorage.setItem(WEBHOOK_STORAGE_KEY, JSON.stringify(config));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Read the ?url= share parameter (used by the Send to Serve shortcut)
+function getSharedUrl() {
+  try {
+    return new URLSearchParams(window.location.search).get("url")?.trim() || "";
+  } catch {
+    return "";
+  }
 }
 
 const MEDIA_CONFIG = {
@@ -217,7 +287,7 @@ const MEDIA_CONFIG = {
   audio: { icon: ZapIcon, color: "#A855F7", label: "AUDIO", bg: "rgba(168, 85, 247, 0.1)", border: "rgba(168, 85, 247, 0.2)" },
   document: { icon: FileTextIcon, color: "#3B82F6", label: "DOCUMENT", bg: "rgba(59, 130, 246, 0.1)", border: "rgba(59, 130, 246, 0.2)" },
   article: { icon: FileTextIcon, color: "#00E5FF", label: "ARTICLE", bg: "rgba(0, 229, 255, 0.1)", border: "rgba(0, 229, 255, 0.2)" },
-  unknown: { icon: LinkIcon, color: "#64748B", label: "WAITING", bg: "rgba(100, 116, 139, 0.08)", border: "rgba(100, 116, 139, 0.15)" },
+  unknown: { icon: LinkIcon, color: "#64748B", label: "INVALID URL", bg: "rgba(100, 116, 139, 0.08)", border: "rgba(100, 116, 139, 0.15)" },
 };
 
 // ━━━ SHORTCUT TEMPLATES ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -267,33 +337,67 @@ const IFTTT_METHODS = [
 
 // ━━━ MAIN APP ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 export default function App() {
-  const [inputUrl, setInputUrl] = useState("");
+  // Accept shared URLs on load via ?url= (populated by the Send to Serve shortcut)
+  const [inputUrl, setInputUrl] = useState(getSharedUrl);
   const [copied, setCopied] = useState(false);
-  const [mediaType, setMediaType] = useState("unknown");
   const [activeTab, setActiveTab] = useState("execute");
   const [expandedShortcut, setExpandedShortcut] = useState(null);
   const [pushState, setPushState] = useState("idle");
+  const [webhookConfig, setWebhookConfig] = useState(loadWebhookConfig);
+  const [webhookDraft, setWebhookDraft] = useState(webhookConfig);
+  const [webhookSaved, setWebhookSaved] = useState(false);
+  const [webhookState, setWebhookState] = useState("idle");
+  const tabRefs = useRef({});
+
+  const parsedUrl = parseWebUrl(inputUrl);
+  const mediaType = detectMediaType(inputUrl);
+  const canRoute = Boolean(parsedUrl);
+  const webhookConfigured = Boolean(webhookConfig.event && webhookConfig.key);
 
   const handleUrlChange = (e) => {
-    const v = e.target.value;
-    setInputUrl(v);
-    setMediaType(detectMediaType(v));
+    setInputUrl(e.target.value);
     setPushState("idle");
+    setWebhookState("idle");
   };
 
   const handlePushToSafari = () => {
-    if (!inputUrl) return;
+    if (!parsedUrl) return;
     setPushState("pushing");
     setTimeout(() => {
       setPushState("done");
-      const encoded = encodeURIComponent(inputUrl);
+      const encoded = encodeURIComponent(parsedUrl.href);
       window.location.href = `shortcuts://run-shortcut?name=ForceSafari&input=text&text=${encoded}`;
+      setTimeout(() => setPushState("idle"), 2500);
     }, 600);
   };
 
+  const handleSaveToHome = () => {
+    setActiveTab("shortcuts");
+    setExpandedShortcut("save-to-home");
+  };
+
   const handleIFTTT = () => {
-    if (!inputUrl) return;
-    alert(`IFTTT Webhook would fire with payload:\n${inputUrl}`);
+    if (!parsedUrl) return;
+    if (!webhookConfigured) {
+      // Nothing to fire yet — take the user to the webhook config instead
+      setActiveTab("automate");
+      return;
+    }
+    setWebhookState("sending");
+    const endpoint = `https://maker.ifttt.com/trigger/${encodeURIComponent(webhookConfig.event)}/with/key/${encodeURIComponent(webhookConfig.key)}?value1=${encodeURIComponent(parsedUrl.href)}`;
+    // no-cors: IFTTT doesn't send CORS headers; the response is opaque, so
+    // resolution means "dispatched", not "verified delivered"
+    fetch(endpoint, { method: "POST", mode: "no-cors" })
+      .then(() => setWebhookState("sent"))
+      .catch(() => setWebhookState("error"));
+  };
+
+  const handleWebhookSave = () => {
+    const next = { event: webhookDraft.event.trim(), key: webhookDraft.key.trim() };
+    setWebhookConfig(next);
+    saveWebhookConfig(next);
+    setWebhookSaved(true);
+    setTimeout(() => setWebhookSaved(false), 2000);
   };
 
   const copyToClipboard = () => {
@@ -311,6 +415,16 @@ export default function App() {
     { id: "shortcuts", label: "Shortcuts" },
     { id: "automate", label: "Automate" },
   ];
+
+  // Roving arrow-key navigation between tabs (WAI-ARIA tabs pattern)
+  const handleTabKeyDown = (e, index) => {
+    if (e.key !== "ArrowRight" && e.key !== "ArrowLeft") return;
+    e.preventDefault();
+    const delta = e.key === "ArrowRight" ? 1 : -1;
+    const next = tabs[(index + delta + tabs.length) % tabs.length];
+    setActiveTab(next.id);
+    tabRefs.current[next.id]?.focus();
+  };
 
   return (
     <div style={{
@@ -347,6 +461,20 @@ button { cursor: pointer; border: none; background: none; font-family: inherit; 
 @keyframes pulseGlow { 0%, 100% { opacity: 0.5; } 50% { opacity: 1; } }
 @keyframes shimmer { 0% { background-position: -200% 0; } 100% { background-position: 200% 0; } }
 @keyframes breathe { 0%, 100% { opacity: 0.4; transform: scale(1); } 50% { opacity: 0.7; transform: scale(1.05); } }
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+
+button:focus-visible, input:focus-visible, a:focus-visible {
+  outline: 2px solid rgba(0, 229, 255, 0.6);
+  outline-offset: 2px;
+  border-radius: 8px;
+}
 
 .fade-up { animation: fadeUp 0.4s ease-out both; }
 .fade-up-1 { animation-delay: 0.05s; }
@@ -489,7 +617,7 @@ button { cursor: pointer; border: none; background: none; font-family: inherit; 
               background: "rgba(0, 229, 255, 0.1)", border: "1px solid rgba(0, 229, 255, 0.25)",
               color: "#00E5FF", fontSize: 10, fontWeight: 700, letterSpacing: "0.05em",
             }}>
-              v2.0
+              v2.1
             </span>
           </div>
 
@@ -518,11 +646,18 @@ button { cursor: pointer; border: none; background: none; font-family: inherit; 
           }}>
 
             {/* TABS */}
-            <div className="fade-up fade-up-1" style={{ display: "flex", gap: 0, marginBottom: 24, borderBottom: "1px solid rgba(100, 116, 139, 0.12)", paddingBottom: 0 }}>
-              {tabs.map((tab) => (
+            <div className="fade-up fade-up-1" role="tablist" aria-label="SafariServe sections" style={{ display: "flex", gap: 0, marginBottom: 24, borderBottom: "1px solid rgba(100, 116, 139, 0.12)", paddingBottom: 0 }}>
+              {tabs.map((tab, index) => (
                 <button
                   key={tab.id}
+                  ref={(el) => { tabRefs.current[tab.id] = el; }}
+                  role="tab"
+                  id={`tab-${tab.id}`}
+                  aria-controls={`panel-${tab.id}`}
+                  aria-selected={activeTab === tab.id}
+                  tabIndex={activeTab === tab.id ? 0 : -1}
                   onClick={() => setActiveTab(tab.id)}
+                  onKeyDown={(e) => handleTabKeyDown(e, index)}
                   style={{
                     flex: 1, padding: "10px 0 12px", fontSize: 12, fontWeight: 700,
                     fontFamily: "'Outfit', sans-serif",
@@ -546,7 +681,7 @@ button { cursor: pointer; border: none; background: none; font-family: inherit; 
 
             {/* ═══ TAB: EXECUTE / ROUTE ═══ */}
             {activeTab === "execute" && (
-              <div className="fade-up fade-up-2">
+              <div className="fade-up fade-up-2" role="tabpanel" id="panel-execute" aria-labelledby="tab-execute">
                 {/* Payload Section */}
                 <div style={{ marginBottom: 28 }}>
                   <h2 style={{ fontFamily: "'Outfit', sans-serif", fontSize: 18, fontWeight: 700, letterSpacing: "0.08em", color: "#B8CCE0", marginBottom: 4, textTransform: "uppercase" }}>
@@ -567,6 +702,7 @@ button { cursor: pointer; border: none; background: none; font-family: inherit; 
                       value={inputUrl}
                       onChange={handleUrlChange}
                       placeholder="Paste media URL here..."
+                      aria-label="Media URL"
                       style={{
                         flex: 1, background: "transparent", border: "none", color: "#E2E8F0",
                         fontSize: 15, padding: "10px 0", fontFamily: "inherit",
@@ -574,6 +710,7 @@ button { cursor: pointer; border: none; background: none; font-family: inherit; 
                     />
                     <button
                       onClick={copyToClipboard}
+                      aria-label={copied ? "Copied" : "Copy URL"}
                       style={{
                         padding: 10, borderRadius: 12, flexShrink: 0, transition: "all 0.2s",
                         background: copied ? "rgba(34, 197, 94, 0.15)" : "rgba(100, 116, 139, 0.08)",
@@ -586,7 +723,7 @@ button { cursor: pointer; border: none; background: none; font-family: inherit; 
 
                   {/* Media type badge */}
                   {inputUrl && (
-                    <div className="fade-up" style={{
+                    <div className="fade-up" role="status" style={{
                       marginTop: 10, display: "inline-flex", alignItems: "center", gap: 8,
                       padding: "6px 12px", borderRadius: 10,
                       background: mc.bg, border: `1px solid ${mc.border}`,
@@ -608,10 +745,10 @@ button { cursor: pointer; border: none; background: none; font-family: inherit; 
                   {/* Push to Safari */}
                   <button
                     onClick={handlePushToSafari}
-                    disabled={!inputUrl}
+                    disabled={!canRoute}
                     style={{
                       width: "100%", position: "relative",
-                      opacity: inputUrl ? 1 : 0.4, pointerEvents: inputUrl ? "auto" : "none",
+                      opacity: canRoute ? 1 : 0.4, pointerEvents: canRoute ? "auto" : "none",
                     }}
                   >
                     <div style={{
@@ -647,10 +784,10 @@ button { cursor: pointer; border: none; background: none; font-family: inherit; 
                     </div>
                   </button>
 
-                  {/* Add to Home Screen */}
+                  {/* Add to Home Screen — opens the step-by-step guide */}
                   <button
-                    disabled={!inputUrl}
-                    style={{ width: "100%", opacity: inputUrl ? 1 : 0.4, pointerEvents: inputUrl ? "auto" : "none" }}
+                    onClick={handleSaveToHome}
+                    style={{ width: "100%" }}
                   >
                     <div style={{
                       display: "flex", alignItems: "center", justifyContent: "space-between",
@@ -665,7 +802,7 @@ button { cursor: pointer; border: none; background: none; font-family: inherit; 
                         </div>
                         <div style={{ textAlign: "left" }}>
                           <div style={{ fontWeight: 700, fontSize: 15, color: "#B8CCE0" }}>Save to Home Screen</div>
-                          <div style={{ fontSize: 12, color: "#3D5068", marginTop: 2 }}>Once in Safari → Share → Add to Home</div>
+                          <div style={{ fontSize: 12, color: "#3D5068", marginTop: 2 }}>View the guide: Share → Add to Home Screen</div>
                         </div>
                       </div>
                       <ChevronRightIcon size={18} style={{ color: "#253040" }} />
@@ -675,23 +812,35 @@ button { cursor: pointer; border: none; background: none; font-family: inherit; 
                   {/* IFTTT Webhook */}
                   <button
                     onClick={handleIFTTT}
-                    disabled={!inputUrl}
-                    style={{ width: "100%", opacity: inputUrl ? 1 : 0.4, pointerEvents: inputUrl ? "auto" : "none" }}
+                    disabled={!canRoute || webhookState === "sending"}
+                    style={{ width: "100%", opacity: canRoute ? 1 : 0.4, pointerEvents: canRoute ? "auto" : "none" }}
                   >
                     <div style={{
                       display: "flex", alignItems: "center", justifyContent: "space-between",
                       padding: "16px 18px", borderRadius: 18,
-                      background: "rgba(8, 16, 30, 0.35)", border: "1px solid rgba(100, 116, 139, 0.08)",
+                      background: "rgba(8, 16, 30, 0.35)",
+                      border: `1px solid ${webhookState === "sent" ? "rgba(34, 197, 94, 0.25)" : webhookState === "error" ? "rgba(255, 77, 106, 0.25)" : "rgba(100, 116, 139, 0.08)"}`,
                       transition: "all 0.2s",
                       boxShadow: "inset 0 1px 0 rgba(255,255,255,0.02)",
                     }}>
                       <div style={{ display: "flex", alignItems: "center", gap: 14 }}>
-                        <div style={{ padding: 11, borderRadius: 14, background: "rgba(168, 85, 247, 0.1)", color: "#A855F7" }}>
-                          <ZapIcon size={22} />
+                        <div style={{
+                          padding: 11, borderRadius: 14,
+                          background: webhookState === "sent" ? "rgba(34, 197, 94, 0.12)" : "rgba(168, 85, 247, 0.1)",
+                          color: webhookState === "sent" ? "#22C55E" : "#A855F7",
+                          transition: "all 0.3s",
+                        }}>
+                          {webhookState === "sent" ? <CheckIcon size={22} /> : <ZapIcon size={22} />}
                         </div>
                         <div style={{ textAlign: "left" }}>
                           <div style={{ fontWeight: 700, fontSize: 15, color: "#B8CCE0" }}>Trigger IFTTT Webhook</div>
-                          <div style={{ fontSize: 12, color: "#3D5068", marginTop: 2 }}>Send payload to automation logic</div>
+                          <div style={{ fontSize: 12, color: webhookState === "error" ? "#FF4D6A" : "#3D5068", marginTop: 2 }}>
+                            {webhookState === "sending" ? "Dispatching payload..."
+                              : webhookState === "sent" ? "Payload dispatched"
+                              : webhookState === "error" ? "Dispatch failed — check connection"
+                              : webhookConfigured ? "Send payload to automation logic"
+                              : "Set up your webhook in Automate"}
+                          </div>
                         </div>
                       </div>
                       <ShareIcon size={16} style={{ color: "#253040" }} />
@@ -703,7 +852,7 @@ button { cursor: pointer; border: none; background: none; font-family: inherit; 
 
             {/* ═══ TAB: SHORTCUTS ═══ */}
             {activeTab === "shortcuts" && (
-              <div className="fade-up fade-up-2">
+              <div className="fade-up fade-up-2" role="tabpanel" id="panel-shortcuts" aria-labelledby="tab-shortcuts">
                 <h2 style={{ fontFamily: "'Outfit', sans-serif", fontSize: 18, fontWeight: 700, letterSpacing: "0.08em", color: "#B8CCE0", marginBottom: 4, textTransform: "uppercase" }}>
                   Shortcut Construction
                 </h2>
@@ -795,7 +944,7 @@ button { cursor: pointer; border: none; background: none; font-family: inherit; 
 
             {/* ═══ TAB: AUTOMATE ═══ */}
             {activeTab === "automate" && (
-              <div className="fade-up fade-up-2">
+              <div className="fade-up fade-up-2" role="tabpanel" id="panel-automate" aria-labelledby="tab-automate">
                 <h2 style={{ fontFamily: "'Outfit', sans-serif", fontSize: 18, fontWeight: 700, letterSpacing: "0.08em", color: "#B8CCE0", marginBottom: 4, textTransform: "uppercase" }}>
                   Automation Methods
                 </h2>
@@ -829,9 +978,61 @@ button { cursor: pointer; border: none; background: none; font-family: inherit; 
                   <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 8 }}>
                     <SettingsIcon size={14} style={{ color: "#00E5FF" }} />
                     <span style={{ fontFamily: "'Outfit', sans-serif", fontSize: 12, fontWeight: 700, color: "#00E5FF", letterSpacing: "0.08em" }}>WEBHOOK CONFIG</span>
+                    {webhookConfigured && (
+                      <span style={{
+                        marginLeft: "auto", fontSize: 9, fontWeight: 700, padding: "3px 8px", borderRadius: 6,
+                        background: "rgba(34, 197, 94, 0.1)", color: "#22C55E",
+                        border: "1px solid rgba(34, 197, 94, 0.2)", letterSpacing: "0.08em",
+                      }}>ACTIVE</span>
+                    )}
                   </div>
-                  <p style={{ fontSize: 12, color: "#3D5068", lineHeight: 1.6 }}>
-                    Set your IFTTT Maker webhook key in the SafariServe config to enable direct payload dispatch. The webhook URL follows the pattern: <span style={{ fontFamily: "monospace", color: "#4A6178", wordBreak: "break-all" }}>https://maker.ifttt.com/trigger/&#123;event&#125;/with/key/&#123;your_key&#125;</span>
+                  <p style={{ fontSize: 12, color: "#3D5068", lineHeight: 1.6, marginBottom: 12 }}>
+                    Enter your IFTTT Maker event name and key to enable direct payload dispatch from the Route tab. The webhook fires: <span style={{ fontFamily: "monospace", color: "#4A6178", wordBreak: "break-all" }}>https://maker.ifttt.com/trigger/&#123;event&#125;/with/key/&#123;your_key&#125;</span>
+                  </p>
+                  <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                    <input
+                      type="text"
+                      value={webhookDraft.event}
+                      onChange={(e) => setWebhookDraft({ ...webhookDraft, event: e.target.value })}
+                      placeholder="Event name (e.g. safariserve_push)"
+                      aria-label="IFTTT event name"
+                      autoCapitalize="none"
+                      autoCorrect="off"
+                      style={{
+                        background: "rgba(6, 12, 24, 0.7)", border: "1px solid rgba(100, 116, 139, 0.12)",
+                        borderRadius: 12, padding: "10px 14px", color: "#E2E8F0", fontSize: 13, fontFamily: "inherit",
+                      }}
+                    />
+                    <input
+                      type="password"
+                      value={webhookDraft.key}
+                      onChange={(e) => setWebhookDraft({ ...webhookDraft, key: e.target.value })}
+                      placeholder="Maker webhook key"
+                      aria-label="IFTTT Maker webhook key"
+                      autoComplete="off"
+                      style={{
+                        background: "rgba(6, 12, 24, 0.7)", border: "1px solid rgba(100, 116, 139, 0.12)",
+                        borderRadius: 12, padding: "10px 14px", color: "#E2E8F0", fontSize: 13, fontFamily: "inherit",
+                      }}
+                    />
+                    <button
+                      onClick={handleWebhookSave}
+                      disabled={!webhookDraft.event.trim() || !webhookDraft.key.trim()}
+                      style={{
+                        padding: "10px 14px", borderRadius: 12, fontSize: 12, fontWeight: 700,
+                        fontFamily: "'Outfit', sans-serif", letterSpacing: "0.08em", textTransform: "uppercase",
+                        background: webhookSaved ? "rgba(34, 197, 94, 0.12)" : "rgba(0, 229, 255, 0.1)",
+                        color: webhookSaved ? "#22C55E" : "#00E5FF",
+                        border: `1px solid ${webhookSaved ? "rgba(34, 197, 94, 0.25)" : "rgba(0, 229, 255, 0.25)"}`,
+                        opacity: webhookDraft.event.trim() && webhookDraft.key.trim() ? 1 : 0.4,
+                        transition: "all 0.2s",
+                      }}
+                    >
+                      {webhookSaved ? "Saved" : "Save Config"}
+                    </button>
+                  </div>
+                  <p style={{ fontSize: 11, color: "#3D5068", lineHeight: 1.6, marginTop: 10, opacity: 0.8 }}>
+                    Stored only in this browser (localStorage) — your key never leaves the device except to call IFTTT directly.
                   </p>
                 </div>
               </div>
@@ -868,7 +1069,7 @@ button { cursor: pointer; border: none; background: none; font-family: inherit; 
           </div>
 
           <div className="footer-suite-tag">A VASEY/AI Production</div>
-          <div className="footer-app-tag">SafariServe v2.0 &middot; Intelligent URL Relay Utility</div>
+          <div className="footer-app-tag">SafariServe v2.1 &middot; Intelligent URL Relay Utility</div>
           <div className="footer-copyright">
             &copy; 2026 <a href="https://vaseymultimedia.com" target="_blank" rel="noopener">VASEY Multimedia</a>. All rights reserved.<br/>
             Designed &amp; engineered by <a href="https://vasey.ai" target="_blank" rel="noopener">VASEY/AI</a>

--- a/src/__tests__/App.test.jsx
+++ b/src/__tests__/App.test.jsx
@@ -1,8 +1,13 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, afterEach, vi } from "vitest";
 import { render, screen, fireEvent, cleanup } from "@testing-library/react";
 import App from "../App";
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  window.localStorage.clear();
+  window.history.replaceState({}, "", "/");
+  vi.unstubAllGlobals();
+});
 
 describe("App", () => {
   it("renders without crashing", () => {
@@ -101,7 +106,7 @@ describe("App", () => {
 
   it("renders the version badge", () => {
     render(<App />);
-    expect(screen.getByText("v2.0")).toBeInTheDocument();
+    expect(screen.getByText("v2.1")).toBeInTheDocument();
   });
 
   it("renders Push to Safari button", () => {
@@ -118,5 +123,133 @@ describe("App", () => {
     render(<App />);
     fireEvent.click(screen.getByText("Automate"));
     expect(screen.getByText("WEBHOOK CONFIG")).toBeInTheDocument();
+  });
+});
+
+describe("Shared URL intake (?url=)", () => {
+  it("pre-fills the input from the ?url= query parameter", () => {
+    window.history.replaceState({}, "", "/?url=" + encodeURIComponent("https://youtube.com/watch?v=abc"));
+    render(<App />);
+    expect(screen.getByLabelText("Media URL")).toHaveValue("https://youtube.com/watch?v=abc");
+    expect(screen.getByText("VIDEO")).toBeInTheDocument();
+  });
+
+  it("renders normally when no ?url= parameter is present", () => {
+    render(<App />);
+    expect(screen.getByLabelText("Media URL")).toHaveValue("");
+  });
+});
+
+describe("URL validation", () => {
+  it("flags unparseable input as invalid and disables Push to Safari", () => {
+    render(<App />);
+    fireEvent.change(screen.getByLabelText("Media URL"), { target: { value: "not a url" } });
+    expect(screen.getByText("INVALID URL")).toBeInTheDocument();
+    expect(screen.getByText("Push to Safari").closest("button")).toBeDisabled();
+  });
+
+  it("rejects javascript: scheme URLs", () => {
+    render(<App />);
+    fireEvent.change(screen.getByLabelText("Media URL"), { target: { value: "javascript:alert(1)" } });
+    expect(screen.getByText("INVALID URL")).toBeInTheDocument();
+    expect(screen.getByText("Push to Safari").closest("button")).toBeDisabled();
+  });
+
+  it("accepts bare domains by assuming https", () => {
+    render(<App />);
+    fireEvent.change(screen.getByLabelText("Media URL"), { target: { value: "example.com/article" } });
+    expect(screen.getByText("ARTICLE")).toBeInTheDocument();
+    expect(screen.getByText("Push to Safari").closest("button")).toBeEnabled();
+  });
+
+  it("is not fooled by media hostnames in query strings", () => {
+    render(<App />);
+    fireEvent.change(screen.getByLabelText("Media URL"), { target: { value: "https://evil.com/?ref=youtube.com" } });
+    expect(screen.getByText("ARTICLE")).toBeInTheDocument();
+  });
+
+  it("classifies subdomains of media hosts correctly", () => {
+    render(<App />);
+    fireEvent.change(screen.getByLabelText("Media URL"), { target: { value: "https://open.spotify.com/track/123" } });
+    expect(screen.getByText("AUDIO")).toBeInTheDocument();
+  });
+});
+
+describe("Save to Home Screen", () => {
+  it("opens the Shortcuts tab with the guide expanded", () => {
+    render(<App />);
+    fireEvent.click(screen.getByText("Save to Home Screen"));
+    expect(screen.getByText("Shortcut Construction")).toBeInTheDocument();
+    expect(screen.getByText('"Add to Home Screen"')).toBeInTheDocument();
+  });
+});
+
+describe("IFTTT webhook", () => {
+  it("routes to the Automate tab when unconfigured", () => {
+    render(<App />);
+    fireEvent.change(screen.getByLabelText("Media URL"), { target: { value: "https://example.com" } });
+    fireEvent.click(screen.getByText("Trigger IFTTT Webhook"));
+    expect(screen.getByText("WEBHOOK CONFIG")).toBeInTheDocument();
+  });
+
+  it("saves webhook config to localStorage", () => {
+    render(<App />);
+    fireEvent.click(screen.getByText("Automate"));
+    fireEvent.change(screen.getByLabelText("IFTTT event name"), { target: { value: "safariserve_push" } });
+    fireEvent.change(screen.getByLabelText("IFTTT Maker webhook key"), { target: { value: "test-key-123" } });
+    fireEvent.click(screen.getByText("Save Config"));
+    expect(screen.getByText("Saved")).toBeInTheDocument();
+    expect(screen.getByText("ACTIVE")).toBeInTheDocument();
+    expect(JSON.parse(window.localStorage.getItem("safariserve.webhook"))).toEqual({
+      event: "safariserve_push",
+      key: "test-key-123",
+    });
+  });
+
+  it("dispatches the payload to the configured IFTTT endpoint", async () => {
+    window.localStorage.setItem("safariserve.webhook", JSON.stringify({ event: "my_event", key: "my_key" }));
+    const fetchMock = vi.fn().mockResolvedValue({});
+    vi.stubGlobal("fetch", fetchMock);
+    render(<App />);
+    fireEvent.change(screen.getByLabelText("Media URL"), { target: { value: "https://example.com/page" } });
+    fireEvent.click(screen.getByText("Trigger IFTTT Webhook"));
+    expect(await screen.findByText("Payload dispatched")).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledWith(
+      `https://maker.ifttt.com/trigger/my_event/with/key/my_key?value1=${encodeURIComponent("https://example.com/page")}`,
+      { method: "POST", mode: "no-cors" },
+    );
+  });
+
+  it("shows an error state when dispatch fails", async () => {
+    window.localStorage.setItem("safariserve.webhook", JSON.stringify({ event: "my_event", key: "my_key" }));
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network")));
+    render(<App />);
+    fireEvent.change(screen.getByLabelText("Media URL"), { target: { value: "https://example.com/page" } });
+    fireEvent.click(screen.getByText("Trigger IFTTT Webhook"));
+    expect(await screen.findByText(/Dispatch failed/)).toBeInTheDocument();
+  });
+});
+
+describe("Tab accessibility", () => {
+  it("exposes ARIA tablist semantics", () => {
+    render(<App />);
+    expect(screen.getByRole("tablist")).toBeInTheDocument();
+    const tabs = screen.getAllByRole("tab");
+    expect(tabs).toHaveLength(3);
+    expect(tabs[0]).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByRole("tabpanel")).toHaveAccessibleName("Route");
+  });
+
+  it("moves between tabs with arrow keys", () => {
+    render(<App />);
+    const [routeTab] = screen.getAllByRole("tab");
+    fireEvent.keyDown(routeTab, { key: "ArrowRight" });
+    expect(screen.getByRole("tab", { name: "Shortcuts" })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByText("Shortcut Construction")).toBeInTheDocument();
+  });
+
+  it("labels the copy button for screen readers", () => {
+    render(<App />);
+    expect(screen.getByRole("button", { name: "Copy URL" })).toBeInTheDocument();
   });
 });

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,12 +1,22 @@
 # Task Plan
 
-## Current Session: Update CLAUDE.md Standards & Repo Housekeeping
+## Current Session: Functionality & Design Improvements (v2.1.0)
 
-- [x] Explore repo structure and current state
-- [x] Replace CLAUDE.md with updated engineering standards
-- [x] Fix docs/banner.svg: version (v1.2.0 → v2.0.0), tech badges (TypeScript → JavaScript, Tailwind CSS 4 → Inline Styles), tagline alignment
-- [x] Update README.md: add hero screenshot placeholder, complete public/ manifest in project structure
-- [x] Verify all required repo files present
-- [x] Update CHANGELOG.md with session changes
+- [x] Review repo for functionality/design gaps against README, lessons.md, and CLAUDE.md standards
+- [x] Implement `?url=` query parameter intake (documented in README but missing)
+- [x] Replace IFTTT `alert()` stub with real webhook config (localStorage) + dispatch with status feedback
+- [x] Wire up non-functional "Save to Home Screen" button → opens Shortcuts tab guide
+- [x] Harden media detection: URL parsing + hostname matching (no substring spoofing), reject non-http(s) schemes
+- [x] A11y: ARIA tabs pattern with arrow-key navigation, aria-labels, focus-visible outlines, aria-hidden canvas
+- [x] `prefers-reduced-motion`: static canvas frame + CSS animation opt-out
+- [x] Canvas: devicePixelRatio-aware rendering, particles spawn across real dimensions
+- [x] Add 15 tests for new behavior (33 total)
+- [x] Bump version to 2.1.0 across package.json, badge, footer, test, banner.svg, README
+- [x] Update CHANGELOG.md (fold long-lived [Unreleased] icon work into 2.1.0)
 - [x] Verify: lint, test, build
-- [x] Commit and push
+- [ ] Commit and push, open draft PR
+
+## Deferred
+
+- Bundle size: the inline `?raw` icon SVG dominates the JS chunk (~599 kB minified / 188 kB gzip). Consider optimizing the SVG source (SVGO) or loading it as a static asset instead of inlining into the bundle.
+- Consider a "Paste from clipboard" affordance next to the copy button for the manual iOS flow.


### PR DESCRIPTION
## Summary

This PR closes the gap between what SafariServe's docs promise and what the app actually does, and brings the UI up to the accessibility standards in CLAUDE.md. Version bumped to **2.1.0**.

### Functionality

- **`?url=` query parameter intake** — the README and the Send to Serve shortcut both depend on this, but the app never read it. The Route tab now pre-fills (and classifies) a shared URL on load, completing the Brave → Send to Serve → SafariServe → ForceSafari → Safari pipeline.
- **Real IFTTT webhook** — replaces the `alert()` placeholder. The Automate tab's Webhook Config section is now a working form: enter your Maker event name + key (persisted to `localStorage` only; the key input is masked and the value never leaves the device except to call IFTTT). The Route tab's trigger button dispatches a real `POST` to `maker.ifttt.com` with sending / dispatched / error feedback, and routes you to the config when unconfigured.
- **"Save to Home Screen" button now works** — it previously did nothing (violating the repo's own lessons.md rule against non-functional UI). It now opens the step-by-step guide in the Shortcuts tab.
- **URL validation** — routing actions enable only for parseable http(s) URLs. Bare domains (`example.com/page`) are accepted by assuming `https://`; `javascript:` and other non-web schemes are rejected and flagged `INVALID URL`.
- **Hardened media detection** — URLs are parsed and hostnames matched exactly or by subdomain instead of substring matching, so `evil.com/?ref=youtube.com` is no longer classified as video while `open.spotify.com` still classifies as audio.

### Design & accessibility

- WAI-ARIA tabs pattern: `tablist`/`tab`/`tabpanel` roles, `aria-selected`, roving tabindex, ArrowLeft/ArrowRight navigation.
- `prefers-reduced-motion` support: the canvas mesh renders one static frame and CSS animations are disabled.
- Visible `:focus-visible` outlines; `aria-label`s on the URL input, copy button, and config inputs; `aria-hidden` decorative canvas.
- Canvas respects `devicePixelRatio` (capped at 2×) and spawns particles across real canvas dimensions instead of a hardcoded 500×1400 area.
- Push to Safari resets to idle after completing instead of staying "done" forever.

### Supply chain

- `npm audit fix` resolves all 9 Dependabot-reported vulnerabilities (1 critical / 4 high / 3 moderate / 1 low → 0) via non-breaking updates to vite, vitest, ws, and transitive deps.

### Docs & housekeeping

- CHANGELOG cut as 2.1.0 (folding in the long-lived `[Unreleased]` icon work per the repo's versioning lesson); README features and version badges updated; version synced across package.json, app badge, footer, banner.svg, and tests.

## Verification

- `npm run lint` — clean (0 warnings)
- `npm run test` — 33/33 passing (15 new tests covering shared-URL intake, validation/scheme rejection, webhook config persistence + dispatch + error state, Save to Home Screen navigation, and tab accessibility)
- `npm run build` — succeeds

Known deferred item (tracked in `tasks/todo.md`): the inline `?raw` icon SVG dominates the JS bundle (~599 kB minified); worth optimizing with SVGO or loading as a static asset in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WFzvFiMYfFPkxa7PG96SKK

---
_Generated by [Claude Code](https://claude.ai/code/session_01WFzvFiMYfFPkxa7PG96SKK)_