### PR TITLE
fix: repaint static canvas frame on resize under prefers-reduced-motion (v2.1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [2.1.1] - 2026-07-12
+
+### Fixed
+
+- Repaint the static canvas frame on window resize when `prefers-reduced-motion` is enabled — resizing resets the canvas dimensions (clearing it), and with no animation loop running the background stayed blank (reported in review of #35)
+
 ## [2.1.0] - 2026-07-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <p align="center">
   <a href="https://github.com/SeanVasey/SafariServe/actions/workflows/ci.yml"><img src="https://github.com/SeanVasey/SafariServe/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI"></a>
   <a href="https://github.com/SeanVasey/SafariServe/actions/workflows/deploy-pages.yml"><img src="https://github.com/SeanVasey/SafariServe/actions/workflows/deploy-pages.yml/badge.svg" alt="Deploy"></a>
-  <img src="https://img.shields.io/badge/version-2.1.0-00D2FF?style=flat&labelColor=0A0E14" alt="Version 2.1.0">
+  <img src="https://img.shields.io/badge/version-2.1.1-00D2FF?style=flat&labelColor=0A0E14" alt="Version 2.1.1">
   <a href="https://seanvasey.github.io/SafariServe/"><img src="https://img.shields.io/badge/demo-live-00B4D8?style=flat&labelColor=0A0E14" alt="Live Demo"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-FFB26B?style=flat&labelColor=0A0E14" alt="License"></a>
 </p>

--- a/docs/banner.svg
+++ b/docs/banner.svg
@@ -94,7 +94,7 @@
   <!-- Version badge -->
   <g transform="translate(745, 185)">
     <rect width="52" height="22" rx="11" fill="#00D2FF" fill-opacity="0.1" stroke="#00D2FF" stroke-opacity="0.2" stroke-width="1"/>
-    <text x="26" y="15" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="10" font-weight="700" fill="#00D2FF" letter-spacing="0.5">v2.1.0</text>
+    <text x="26" y="15" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="10" font-weight="700" fill="#00D2FF" letter-spacing="0.5">v2.1.1</text>
   </g>
 
   <!-- Tagline -->

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "safariserve",
   "private": true,
-  "version": "2.1.0",
+  "version": "2.1.1",
   "type": "module",
   "description": "The intelligent jumping-off point for your media.",
   "scripts": {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -86,12 +86,16 @@ function ElectricMeshBackground() {
     const prefersReducedMotion = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
     let animFrame;
     let particles = [];
+    let initialized = false;
     const resize = () => {
       const dpr = Math.min(window.devicePixelRatio || 1, 2);
       canvas.width = canvas.offsetWidth * dpr;
       canvas.height = canvas.offsetHeight * dpr;
       // Setting width/height resets the transform, so this doesn't compound
       ctx.scale(dpr, dpr);
+      // Resizing clears the canvas; with no animation loop running under
+      // prefers-reduced-motion, repaint the static frame or it stays blank
+      if (prefersReducedMotion && initialized) draw();
     };
     resize();
     const w = () => canvas.offsetWidth;
@@ -199,6 +203,7 @@ function ElectricMeshBackground() {
       if (!prefersReducedMotion) animFrame = requestAnimationFrame(draw);
     };
     draw();
+    initialized = true;
     window.addEventListener("resize", resize);
     return () => { cancelAnimationFrame(animFrame); window.removeEventListener("resize", resize); };
   }, []);

--- a/src/__tests__/App.test.jsx
+++ b/src/__tests__/App.test.jsx
@@ -7,6 +7,7 @@ afterEach(() => {
   window.localStorage.clear();
   window.history.replaceState({}, "", "/");
   vi.unstubAllGlobals();
+  vi.restoreAllMocks();
 });
 
 describe("App", () => {
@@ -251,5 +252,26 @@ describe("Tab accessibility", () => {
   it("labels the copy button for screen readers", () => {
     render(<App />);
     expect(screen.getByRole("button", { name: "Copy URL" })).toBeInTheDocument();
+  });
+});
+
+describe("Reduced-motion canvas", () => {
+  it("repaints the static frame after a window resize", () => {
+    // With prefers-reduced-motion there is no animation loop, so a resize
+    // (which clears the canvas) must trigger an explicit redraw
+    const ctxStub = {
+      clearRect: vi.fn(), save: vi.fn(), restore: vi.fn(), beginPath: vi.fn(),
+      moveTo: vi.fn(), lineTo: vi.fn(), closePath: vi.fn(), fill: vi.fn(),
+      stroke: vi.fn(), arc: vi.fn(), fillRect: vi.fn(), scale: vi.fn(),
+      createLinearGradient: () => ({ addColorStop: () => {} }),
+      createRadialGradient: () => ({ addColorStop: () => {} }),
+    };
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(ctxStub);
+    vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({ matches: true }));
+    render(<App />);
+    const framesBefore = ctxStub.clearRect.mock.calls.length;
+    expect(framesBefore).toBeGreaterThan(0);
+    fireEvent(window, new Event("resize"));
+    expect(ctxStub.clearRect.mock.calls.length).toBeGreaterThan(framesBefore);
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #35, addressing the bug flagged in its review (which merged before the fix could land).

With `prefers-reduced-motion` enabled, the mesh background draws a single static frame and never starts an animation loop. Resizing the window resets the canvas dimensions — which clears the canvas — so the background stayed permanently blank after any resize.

The resize handler now repaints the static frame once the initial draw has completed (guarded by an `initialized` flag so the handler never runs `draw()` before setup finishes, and only when reduced motion is active — the animation loop handles repaints otherwise).

Version bumped to **2.1.1** (package.json, README badge, banner.svg) with a CHANGELOG entry.

## Verification

- New regression test (`Reduced-motion canvas > repaints the static frame after a window resize`) **fails without the fix and passes with it** — verified by stashing the fix and re-running
- `npm run lint` — clean
- `npm run test` — 34/34 passing
- `npm run build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WFzvFiMYfFPkxa7PG96SKK

---
_Generated by [Claude Code](https://claude.ai/code/session_01WFzvFiMYfFPkxa7PG96SKK)_